### PR TITLE
Changed favicon dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     
     <meta charset="utf-8">
-    <link rel="icon" href="Images/favicon.ico" type="image/icon" sizes="16x16">
+    <link rel="icon" href="Images/favicon.ico" type="image/icon" sizes="32x32">
     <meta name="viewport" content="device-width, intital-scale=1">
     <link rel="stylesheet" type="text/css" href="style.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>


### PR DESCRIPTION
The original favicon dimensions were 32x32. But in HTML it was left with the default value of 16x16.